### PR TITLE
Version 3.5 - Add support for installing to both pwsh and PowerShell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 on: [push]
 
 jobs:
-  run-on-linux-v2:
+  run-v2-on-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Create variables for module cacher
         id: psmodulecache
-        uses: potatoqualitee/psmodulecache@v3
+        uses: potatoqualitee/psmodulecache@v35
         with:
           modules-to-cache: PSFramework, Pester, dbatools:1.0.1
       - name: Run module cacher action
@@ -18,7 +18,7 @@ jobs:
           key: ${{ steps.psmodulecache.outputs.keygen }}
       - name: Install PowerShell modules
         if: steps.cacher.outputs.cache-hit != 'true'
-        uses: potatoqualitee/psmodulecache@v3
+        uses: potatoqualitee/psmodulecache@v35
         with:
           modules-to-cache-final: ${{ steps.psmodulecache.outputs.modules-to-cache }}
       - name: Show that the Action works
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Create variables for module cacher
         id: psmodulecache
-        uses: potatoqualitee/psmodulecache@v3
+        uses: potatoqualitee/psmodulecache@v35
         with:
           modules-to-cache: PSFramework, Pester, dbatools:1.0.1
       - name: Run module cacher action
@@ -44,7 +44,7 @@ jobs:
           key: ${{ steps.psmodulecache.outputs.keygen }}
       - name: Install PowerShell modules
         if: steps.cacher.outputs.cache-hit != 'true'
-        uses: potatoqualitee/psmodulecache@v3
+        uses: potatoqualitee/psmodulecache@v35
         with:
           modules-to-cache-final: ${{ steps.psmodulecache.outputs.modules-to-cache }}
       - name: Show that the Action works
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Create variables for module cacher
         id: psmodulecache
-        uses: potatoqualitee/psmodulecache@v3
+        uses: potatoqualitee/psmodulecache@v35
         with:
           modules-to-cache: PoshRSJob
           shell: powershell
@@ -71,7 +71,7 @@ jobs:
           key: ${{ steps.psmodulecache.outputs.keygen }}
       - name: Install PowerShell modules
         if: steps.cacher.outputs.cache-hit != 'true'
-        uses: potatoqualitee/psmodulecache@v3
+        uses: potatoqualitee/psmodulecache@v35
       - name: Show that the Action works
         shell: powershell
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,4 +104,6 @@ jobs:
         run: |
           Get-Module -Name PoshRSJob -ListAvailable | Select Path
           Import-Module PoshRSJob
+          powershell -command "Write-Warning 'GETTING MODULE'"
+          powershell -command "Get-Module -Name PoshRSJob -ListAvailable | Select Path"
           powershell -command "Import-Module PoshRSJob -ErrorAction Stop"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,6 @@ jobs:
       - name: Install PowerShell modules
         if: steps.cacher.outputs.cache-hit != 'true'
         uses: potatoqualitee/psmodulecache@v35
-        with:
-          modules-to-cache-final: ${{ steps.psmodulecache.outputs.modules-to-cache }}
       - name: Show that the Action works
         shell: pwsh
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,3 +77,30 @@ jobs:
         run: |
           Get-Module -Name PoshRSJob -ListAvailable | Select Path
           Import-Module PoshRSJob
+
+
+  run-on-both:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create variables for module cacher
+        id: psmodulecache
+        uses: potatoqualitee/psmodulecache@v35
+        with:
+          modules-to-cache: PoshRSJob
+          shell: powershell, pwsh
+      - name: Run module cacher action
+        id: cacher
+        uses: actions/cache@v2
+        with:
+          key: ${{ steps.psmodulecache.outputs.keygen }}
+          path: |
+            ${{ steps.psmodulecache.outputs.modulepath }}
+      - name: Install PowerShell modules
+        if: steps.cacher.outputs.cache-hit != 'true'
+        uses: potatoqualitee/psmodulecache@v3
+      - name: Show that the Action works
+        shell: powershell
+        run: |
+          Get-Module -Name PoshRSJob -ListAvailable | Select Path
+          Import-Module PoshRSJob

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,11 +99,13 @@ jobs:
       - name: Install PowerShell modules
         if: steps.cacher.outputs.cache-hit != 'true'
         uses: potatoqualitee/psmodulecache@v35
-      - name: Show that the Action works
+      - name: Show that the Action works on pwsh
+        shell: pwsh
+        run: |
+          Get-Module -Name PoshRSJob -ListAvailable | Select Path
+          Import-Module PoshRSJob
+      - name: Show that the Action works on PowerShell
         shell: powershell
         run: |
           Get-Module -Name PoshRSJob -ListAvailable | Select Path
           Import-Module PoshRSJob
-          powershell -command "Write-Warning 'GETTING MODULE'"
-          powershell -command "Get-Module -Name PoshRSJob -ListAvailable | Select Path"
-          powershell -command "Import-Module PoshRSJob -ErrorAction Stop"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
             ${{ steps.psmodulecache.outputs.modulepath }}
       - name: Install PowerShell modules
         if: steps.cacher.outputs.cache-hit != 'true'
-        uses: potatoqualitee/psmodulecache@v3
+        uses: potatoqualitee/psmodulecache@v35
       - name: Show that the Action works
         shell: powershell
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,32 @@
 on: [push]
 
 jobs:
+  run-on-linux-v2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create variables for module cacher
+        id: psmodulecache
+        uses: potatoqualitee/psmodulecache@v2
+        with:
+          modules-to-cache: PSFramework, Pester, dbatools:1.0.1
+      - name: Run module cacher action
+        id: cacher
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.psmodulecache.outputs.modulepath }}
+          key: ${{ steps.psmodulecache.outputs.keygen }}
+      - name: Install PowerShell modules
+        if: steps.cacher.outputs.cache-hit != 'true'
+        uses: potatoqualitee/psmodulecache@v2
+        with:
+          modules-to-cache-final: ${{ steps.psmodulecache.outputs.modules-to-cache }}
+      - name: Show that the Action works
+        shell: pwsh
+        run: |
+          Get-Module -Name dbatools -ListAvailable | Select Path
+          Import-Module PSFramework
+
   run-on-linux:
     runs-on: ubuntu-latest
     steps:
@@ -19,8 +45,6 @@ jobs:
       - name: Install PowerShell modules
         if: steps.cacher.outputs.cache-hit != 'true'
         uses: potatoqualitee/psmodulecache@v35
-        with:
-          modules-to-cache-final: ${{ steps.psmodulecache.outputs.modules-to-cache }}
       - name: Show that the Action works
         shell: pwsh
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Show that the Action works on pwsh
         shell: pwsh
         run: |
-          Get-Module -Name PoshRSJob -ListAvailable | Select Path
+          Get-Module -Name PoshRSJob, dbatools -ListAvailable | Select Path
           Import-Module PoshRSJob
       - name: Show that the Action works on PowerShell
         shell: powershell

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           Import-Module PoshRSJob
 
 
-  run-on-both:
+  run-for-both-pwsh-and-powershell:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
         id: psmodulecache
         uses: potatoqualitee/psmodulecache@v35
         with:
-          modules-to-cache: PoshRSJob
+          modules-to-cache: PoshRSJob, dbatools
           shell: powershell, pwsh
       - name: Run module cacher action
         id: cacher
@@ -129,5 +129,5 @@ jobs:
       - name: Show that the Action works on PowerShell
         shell: powershell
         run: |
-          Get-Module -Name PoshRSJob -ListAvailable | Select Path
+          Get-Module -Name PoshRSJob, dbatools -ListAvailable | Select Path
           Import-Module PoshRSJob

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,3 +104,4 @@ jobs:
         run: |
           Get-Module -Name PoshRSJob -ListAvailable | Select Path
           Import-Module PoshRSJob
+          powershell -command "Import-Module PoshRSJob -ErrorAction Stop"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Once GitHub supports [using actions in composite actions](https://github.com/act
 ```yaml
     - name: Create variables for module cacher
       id: psmodulecache
-      uses: potatoqualitee/psmodulecache@v3
+      uses: potatoqualitee/psmodulecache@v3.5
       with:
         modules-to-cache: PSFramework, Pester, dbatools
     - name: Run module cacher action
@@ -26,7 +26,7 @@ Once GitHub supports [using actions in composite actions](https://github.com/act
         key: ${{ steps.psmodulecache.outputs.keygen }}
     - name: Install PowerShell modules
       if: steps.cacher.outputs.cache-hit != 'true'
-      uses: potatoqualitee/psmodulecache@v3
+      uses: potatoqualitee/psmodulecache@v3.5
 ```
 
 ## Usage
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Create variables for module cacher
       id: psmodulecache
-      uses: potatoqualitee/psmodulecache@v3
+      uses: potatoqualitee/psmodulecache@v3.5
       with:
         modules-to-cache: PSFramework, Pester, dbatools:1.0.0
     - name: Run module cacher action
@@ -74,7 +74,7 @@ jobs:
         key: ${{ steps.psmodulecache.outputs.keygen }}
     - name: Install PowerShell modules
       if: steps.cacher.outputs.cache-hit != 'true'
-      uses: potatoqualitee/psmodulecache@v3
+      uses: potatoqualitee/psmodulecache@v3.5
     - name: Show that the Action works
       shell: pwsh
       run: |
@@ -93,7 +93,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Create variables for module cacher
       id: psmodulecache
-      uses: potatoqualitee/psmodulecache@v3
+      uses: potatoqualitee/psmodulecache@v3.5
       with:
         modules-to-cache: PSFramework, Pester, dbatools:1.0.0
     - name: Run module cacher action
@@ -104,7 +104,7 @@ jobs:
         key: ${{ steps.psmodulecache.outputs.keygen }}
     - name: Install PowerShell modules
       if: steps.cacher.outputs.cache-hit != 'true'
-      uses: potatoqualitee/psmodulecache@v3
+      uses: potatoqualitee/psmodulecache@v3.5
     - name: Show that the Action works
       shell: pwsh
       run: |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 ### Inputs
 
 * `modules-to-cache` - A comma separated list of PowerShell modules to install or cache.
-* `shell` - The default shell to use. Defaults to pwsh. Options are pwsh or powershell.
+* `shell` - The default shell to use. Defaults to pwsh. Options are `pwsh`, `powershell` or `pwsh, powershell` for both pwsh and powershell on Windows.
 * `allow-prerelease` - Allow prerelease during Save-Module. Defaults to true.
 * `force` - Force during Save-Module. Defaults to true.
 

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
 
           $null = $inputs | Export-CliXml -Path (Join-Path $home -ChildPath cache.xml)
         } else {
-          Write-Output "Saving modules"
+          Write-Output "Saving all modules"
           ${{ github.action_path }}/main.ps1 -Type SaveModule
         }
 outputs:

--- a/main.ps1
+++ b/main.ps1
@@ -37,10 +37,13 @@ switch ($Type) {
 
       foreach ($module in $modules) {
          foreach ($psshell in $shells) {
-            $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
+            if ($env:RUNNER_OS -eq "Windows") {
+               $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
             if ($psshell -eq "powershell") {
                $modpath = $modpath.Replace("PowerShell","WindowsPowerShell")
-            }
+            } else {
+               $modpath = ($env:PSModulePath.Split(":") | Select-Object -First 1)
+            } 
             Write-Output "Saving module $module on $psshell to $modpath"
             $item, $version = $module.Split(":")
             if ($version) {

--- a/main.ps1
+++ b/main.ps1
@@ -8,7 +8,7 @@ $shells = $Shell.Split(",").Trim()
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
-      Write-Output "$env:RUNNER_OS-v35test-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
+      Write-Output "$env:RUNNER_OS-v35test1-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
    }
    'ModulePath' {
       if ($env:RUNNER_OS -eq "Windows") {

--- a/main.ps1
+++ b/main.ps1
@@ -17,7 +17,7 @@ switch ($Type) {
             return $modpath.Replace("PowerShell","WindowsPowerShell")
          }
          if ($Shell -eq "pwsh") {
-            return $modpath.Replace("PowerShell","WindowsPowerShell")
+            return $modpath
          }
          if ($shells -contains "pwsh" -and $shells -contains "powershell") {
             return $modpath.Replace("PowerShell","*PowerShell*")

--- a/main.ps1
+++ b/main.ps1
@@ -39,8 +39,9 @@ switch ($Type) {
          foreach ($psshell in $shells) {
             if ($env:RUNNER_OS -eq "Windows") {
                $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
-            if ($psshell -eq "powershell") {
-               $modpath = $modpath.Replace("PowerShell","WindowsPowerShell")
+               if ($psshell -eq "powershell") {
+                  $modpath = $modpath.Replace("PowerShell","WindowsPowerShell")
+               }
             } else {
                $modpath = ($env:PSModulePath.Split(":") | Select-Object -First 1)
             } 

--- a/main.ps1
+++ b/main.ps1
@@ -8,7 +8,7 @@ $shells = $Shell.Split(",").Trim()
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
-      Write-Output "$env:RUNNER_OS-$platform-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
+      Write-Output "$env:RUNNER_OS-v35test-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
    }
    'ModulePath' {
       if ($env:RUNNER_OS -eq "Windows") {
@@ -20,7 +20,7 @@ switch ($Type) {
          if ($shells -contains "pwsh") {
             $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
          }
-         Write-Output $modpaths
+         Write-Output $modpaths -join "`n"
       } else {
          ($env:PSModulePath.Split(":") | Select-Object -First 1)
       }

--- a/main.ps1
+++ b/main.ps1
@@ -8,7 +8,7 @@ $shells = $Shell.Split(",").Trim()
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
-      Write-Output "$env:RUNNER_OS-v35test12-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
+      Write-Output "$env:RUNNER_OS-v35-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
    }
    'ModulePath' {
       if ($env:RUNNER_OS -eq "Windows") {

--- a/main.ps1
+++ b/main.ps1
@@ -31,19 +31,17 @@ switch ($Type) {
       Write-Output "Trusting PSGallery"
       Set-PSRepository PSGallery -InstallationPolicy Trusted
 
-      $modulelist = $moduleinfo.Modules
-      Write-Output "Saving modules $modulelist to $($moduleinfo.ModulePath)"
       $modules = $modulelist.Split(",").Trim()
       $force = [bool]($moduleinfo.force)
       $allowprerelease = [bool]($moduleinfo.allowprerelease)
 
       foreach ($module in $modules) {
          foreach ($psshell in $shellarray) {
-            Write-Output "Installing module $module on $psshell"
             $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
             if ($psshell -eq "powershell") {
                $modpath = $modpath.Replace("PowerShell","WindowsPowerShell")
             }
+            Write-Output "Saving module $module on $psshell to $modpath"
             $item, $version = $module.Split(":")
             if ($version) {
                Save-Module $item -RequiredVersion $version -ErrorAction Stop -Force:$force -AllowPrerelease:$allowprerelease -Path $modpath

--- a/main.ps1
+++ b/main.ps1
@@ -8,19 +8,20 @@ $shells = $Shell.Split(",").Trim()
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
-      Write-Output "$env:RUNNER_OS-v35test1-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
+      Write-Output "$env:RUNNER_OS-v35test12-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
    }
    'ModulePath' {
       if ($env:RUNNER_OS -eq "Windows") {
-         $modpaths = @()
          $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
-         if ($shells -contains "powershell") {
-            $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
+         if ($Shell -eq "powershell") {
+            return $modpath.Replace("PowerShell","WindowsPowerShell")
          }
-         if ($shells -contains "pwsh") {
-            $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
+         if ($Shell -eq "pwsh") {
+            return $modpath.Replace("PowerShell","WindowsPowerShell")
          }
-         Write-Output ($modpaths -join "`n")
+         if ($shells -contains "pwsh" -and $shells -contains "powershell") {
+            return $modpath.Replace("PowerShell","*PowerShell*")
+         }
       } else {
          ($env:PSModulePath.Split(":") | Select-Object -First 1)
       }

--- a/main.ps1
+++ b/main.ps1
@@ -8,7 +8,7 @@ $shells = $Shell.Split(",").Trim()
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
-      Write-Output "$env:RUNNER_OS-v35-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
+      Write-Output "$env:RUNNER_OS-v3.5test-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
    }
    'ModulePath' {
       if ($env:RUNNER_OS -eq "Windows") {

--- a/main.ps1
+++ b/main.ps1
@@ -28,7 +28,7 @@ switch ($Type) {
    }
    'SaveModule' {
       $moduleinfo = Import-CliXml -Path (Join-Path $home -ChildPath cache.xml)
-      Write-Output "Trusting PSGallery"
+      Write-Output "Trusting repository PSGallery"
       Set-PSRepository PSGallery -InstallationPolicy Trusted
       $modules = $moduleinfo.Modules.Split(",").Trim()
       $shells = $moduleinfo.Shell.Split(",").Trim()

--- a/main.ps1
+++ b/main.ps1
@@ -8,7 +8,7 @@ $shells = $Shell.Split(",").Trim()
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
-      Write-Output "$env:RUNNER_OS-v3.5test-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
+      Write-Output "$env:RUNNER_OS-v3.5-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
    }
    'ModulePath' {
       if ($env:RUNNER_OS -eq "Windows") {

--- a/main.ps1
+++ b/main.ps1
@@ -20,7 +20,7 @@ switch ($Type) {
          if ($shells -contains "pwsh") {
             $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
          }
-         Write-Output $modpaths -join "`n"
+         Write-Output ($modpaths -join "`n")
       } else {
          ($env:PSModulePath.Split(":") | Select-Object -First 1)
       }

--- a/main.ps1
+++ b/main.ps1
@@ -4,8 +4,7 @@ param (
    [string]$Type,
    [string]$Shell
 )
-$Shell = $Shell.Replace(" ","")
-$shellarray = $Shell -split ","
+$shellarray = $Shell.Split(",").Trim()
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
@@ -21,7 +20,7 @@ switch ($Type) {
          if ($shellarray -contains "pwsh") {
             $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
          }
-         Write-Output ($modpaths -join "`n            ")
+         Write-Output $modpaths
       } else {
          ($env:PSModulePath.Split(":") | Select-Object -First 1)
       }
@@ -30,7 +29,7 @@ switch ($Type) {
       $moduleinfo = Import-CliXml -Path (Join-Path $home -ChildPath cache.xml)
       Write-Output "Trusting PSGallery"
       Set-PSRepository PSGallery -InstallationPolicy Trusted
-
+      $modulelist = $moduleinfo.Modules
       $modules = $modulelist.Split(",").Trim()
       $force = [bool]($moduleinfo.force)
       $allowprerelease = [bool]($moduleinfo.allowprerelease)

--- a/main.ps1
+++ b/main.ps1
@@ -4,20 +4,20 @@ param (
    [string]$Type,
    [string]$Shell
 )
-$shellarray = $Shell.Split(",").Trim()
+$shells = $Shell.Split(",").Trim()
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
-      Write-Output "$env:RUNNER_OS-$platform-$($shellarray -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
+      Write-Output "$env:RUNNER_OS-$platform-$($shells -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
    }
    'ModulePath' {
       if ($env:RUNNER_OS -eq "Windows") {
          $modpaths = @()
          $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
-         if ($shellarray -contains "powershell") {
+         if ($shells -contains "powershell") {
             $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
          }
-         if ($shellarray -contains "pwsh") {
+         if ($shells -contains "pwsh") {
             $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
          }
          Write-Output $modpaths
@@ -29,13 +29,13 @@ switch ($Type) {
       $moduleinfo = Import-CliXml -Path (Join-Path $home -ChildPath cache.xml)
       Write-Output "Trusting PSGallery"
       Set-PSRepository PSGallery -InstallationPolicy Trusted
-      $modulelist = $moduleinfo.Modules
-      $modules = $modulelist.Split(",").Trim()
+      $modules = $moduleinfo.Modules.Split(",").Trim()
+      $shells = $moduleinfo.Shell.Split(",").Trim()
       $force = [bool]($moduleinfo.force)
       $allowprerelease = [bool]($moduleinfo.allowprerelease)
 
       foreach ($module in $modules) {
-         foreach ($psshell in $shellarray) {
+         foreach ($psshell in $shells) {
             $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
             if ($psshell -eq "powershell") {
                $modpath = $modpath.Replace("PowerShell","WindowsPowerShell")

--- a/main.ps1
+++ b/main.ps1
@@ -2,23 +2,23 @@ param (
    [string[]]$Module,
    [ValidateSet("KeyGen","ModulePath", "SaveModule")]
    [string]$Type,
-   [ValidateSet("pwsh","powershell")]
-   [string[]]$Shell
+   [string]$Shell
 )
-
+$Shell = $Shell.Replace(" ","")
+$shellarray = $Shell -split ","
 switch ($Type) {
    'KeyGen' {
       # all this splitting and joining accomodates for powershell and pwsh
-      Write-Output "$env:RUNNER_OS-$platform-$($Shell -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
+      Write-Output "$env:RUNNER_OS-$platform-$($shellarray -join "-")-$(($Module.Split(",") -join '-').Replace(' ',''))"
    }
    'ModulePath' {
       if ($env:RUNNER_OS -eq "Windows") {
          $modpaths = @()
          $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
-         if ($Shell -contains "powershell") {
+         if ($shellarray -contains "powershell") {
             $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
          }
-         if ($Shell -contains "pwsh") {
+         if ($shellarray -contains "pwsh") {
             $modpaths += $modpath.Replace("PowerShell","WindowsPowerShell")
          }
          Write-Output ($modpaths -join "`n            ")
@@ -38,7 +38,7 @@ switch ($Type) {
       $allowprerelease = [bool]($moduleinfo.allowprerelease)
 
       foreach ($module in $modules) {
-         foreach ($psshell in $Shell) {
+         foreach ($psshell in $shellarray) {
             Write-Output "Installing module $module on $psshell"
             $modpath = ($env:PSModulePath.Split(";") | Select-Object -First 1)
             if ($psshell -eq "powershell") {


### PR DESCRIPTION
Now `shell: powershell, pwsh` is possible.

```
  run-for-both-pwsh-and-powershell:
    runs-on: windows-latest
    steps:
      - uses: actions/checkout@v2
      - name: Create variables for module cacher
        id: psmodulecache
        uses: potatoqualitee/psmodulecache@v35
        with:
          modules-to-cache: PoshRSJob, dbatools
          shell: powershell, pwsh
      - name: Run module cacher action
        id: cacher
        uses: actions/cache@v2
        with:
          key: ${{ steps.psmodulecache.outputs.keygen }}
          path: |
            ${{ steps.psmodulecache.outputs.modulepath }}
      - name: Install PowerShell modules
        if: steps.cacher.outputs.cache-hit != 'true'
        uses: potatoqualitee/psmodulecache@v35
      - name: Show that the Action works on pwsh
        shell: pwsh
        run: |
          Get-Module -Name PoshRSJob, dbatools -ListAvailable | Select Path
          Import-Module PoshRSJob
      - name: Show that the Action works on PowerShell
        shell: powershell
        run: |
          Get-Module -Name PoshRSJob, dbatools -ListAvailable | Select Path
          Import-Module PoshRSJob
```