### PR TITLE
Update readme to fix eg workflows link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you need to use `RequiredVersion`, add a colon then the version: **`modules-t
 ## Usage
 
 ### Pre-requisites
-Create a workflow `.yml` file in your repositories `.github/workflows` directory. An [example workflow](#example-workflow) is available below. For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
+Create a workflow `.yml` file in your repositories `.github/workflows` directory. [Example workflows](#example-workflows) are available below. For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
 
 ### Inputs
 


### PR DESCRIPTION
Tiny change @potatoqualitee, just saw that your workflow examples link slug was not redirecting properly. Sorry for such a small fix, feel free to ignore if you'll fix this later.