### PR TITLE
Fix module name case sensitive

### DIFF
--- a/.github/workflows/UbuntuRestoreCache.yml
+++ b/.github/workflows/UbuntuRestoreCache.yml
@@ -1,0 +1,20 @@
+name: UbuntuRestoreCache
+on: [workflow_dispatch]
+
+jobs:
+  RestoreCache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install and cache PowerShell modules
+        id: psmodulecache
+        uses: ./
+        with:
+          modules-to-cache: PSDeploy, BuildHelpers, PlAtYpS, Pester:5.0.2, EZOut
+          shell: pwsh
+
+      - name: Show the previous action works
+        shell: pwsh
+        run: |
+          Get-Module -Name PSDeploy, BuildHelpers, PlAtYpS, EZOut -ListAvailable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Release Notes
 
+### v5.3
+
+* Fix (#45). Some module names are case-sensitive, and break the implicit (and informal) PascalCase naming rule.
+On Linux, the path names passed as a parameter to the 'Cache' action must be constructed with the nuget package name and not with the name coming from the 'modules-to-cache' parameter of the 'PSModuleCache' action.
+* Fix (#43). Action fails when used with a container job. The 'SUDO' command may not exist in the container.
+* Fix (#38). Updating the setting of output parameters (Github Action).
+* Fix (#35). Change after Github Action commands deprecated.
+* Update 'Readme.md' file.
+
 ### v5.2
 
 * Fix (#40). Now we validate a module version number identical to PowershellGet and not like a Semver 2.0.

--- a/PSModuleCache.psm1
+++ b/PSModuleCache.psm1
@@ -24,7 +24,7 @@ Enum CacheType{
 
 $PSModuleCacheResources = Import-PowerShellDataFile "$PsScriptRoot/PSModuleCache.Resources.psd1" -ErrorAction Stop
 
-New-Variable -Name ActionVersion -Option ReadOnly -Scope Script -Value '5.2'
+New-Variable -Name ActionVersion -Option ReadOnly -Scope Script -Value '5.3'
 
 New-Variable -Name Delimiter -Option ReadOnly -Scope Script -Value '-'
 
@@ -483,8 +483,24 @@ function New-ModuleSavePath {
 #>
    param( $modulecacheinfo )
 
+   $parameters = @{
+      Name            = $null
+      AllowPrerelease = $null
+      Repository      = $script:RepositoryNames
+   }
+
    foreach ($cacheinfo in $modulecacheinfo) {
-      $ModuleName = $cacheinfo.Name
+
+      $parameters.Name = $cacheinfo.Name
+      $parameters.AllowPrerelease = $cacheinfo.Allowprerelease
+
+      #We use the name of the Nuget package which is case sensitive.
+      $NugetPackage = Find-ModuleCacheName @parameters
+      if ($null -eq $NugetPackage)
+      { $ModuleName = $cacheinfo.Name }
+      else
+      { $ModuleName = $NugetPackage.Name }
+
       # For the management of a new version in the directory of an EXISTING module (see the image of the runner)
       # the new version number is added to the name of the save path, if it is specified.
       # We manage the following cases:
@@ -520,6 +536,29 @@ function ConvertTo-YamlLineBreak {
 
    $ofs = '%0A' #https://yaml.org/spec/1.2.2/#54-line-break-characters
    return "$Collection"
+}
+
+function Find-ModuleCacheName {
+   #Fnd the module package name.
+   #On linux, the module name used to build the path, save-module, is that of the Nuget package and not the 'modules-to-cache' parameter.
+   #So you can have case-based name differences.
+
+   #if a module name is present in several repositories we sort the elements by version number then we select the first of the list.
+   #note : Find-Module returns the newest version of a module if no parameters are used that limit the version.
+   [CmdletBinding()]
+   param(
+      $Name,
+      $Repository,
+      $RequiredVersion,
+      [switch]$AllowPrerelease
+   )
+   try {
+      Find-Module @PSBoundParameters -ErrorAction Stop |
+      Sort-Object Version -Descending |
+      Select-Object -First 1
+   } catch [System.Exception] {
+      return $null
+   }
 }
 
 function Find-ModuleCache {
@@ -690,7 +729,7 @@ function New-ModuleCacheParameter {
 }
 
 $parms = @{
-   Function = 'New-ModuleCacheParameter', 'Get-ModuleCache', 'Get-ModuleSavePath', 'New-ModuleSavePath', 'Save-ModuleCache', 'ConvertTo-YamlLineBreak'
+   Function = 'New-ModuleCacheParameter', 'Find-ModuleCacheName', 'Get-ModuleCache', 'Get-ModuleSavePath', 'New-ModuleSavePath', 'Save-ModuleCache', 'ConvertTo-YamlLineBreak'
    Variable = 'CacheFileName', 'RepositoryNames', 'PsWindowsModulePath', 'PsWindowsCoreModulePath', 'PsLinuxCoreModulePath'
 }
 Export-ModuleMember @parms

--- a/PSModuleCache.psm1
+++ b/PSModuleCache.psm1
@@ -479,6 +479,7 @@ function New-ModuleSavePath {
    <#
 .Synopsis
    return one or more module full paths.
+   Modify the case of the module name if necessary.
    Called from Action.yml
 #>
    param( $modulecacheinfo )
@@ -494,19 +495,23 @@ function New-ModuleSavePath {
       $parameters.Name = $cacheinfo.Name
       $parameters.AllowPrerelease = $cacheinfo.Allowprerelease
 
-      #We use the name of the Nuget package which is case sensitive.
+      #If it exists, we use the Nuget package name which is case sensitive.
+      #Otherwise we keep the name received, it will be tested during the second pass ( Save-ModuleCache )
       $NugetPackage = Find-ModuleCacheName @parameters
       if ($null -eq $NugetPackage)
       { $ModuleName = $cacheinfo.Name }
-      else
-      { $ModuleName = $NugetPackage.Name }
+      else {
+         Write-Warning "For the module name '$($cacheinfo.Name)' we use the case of the nuget package name: '$($NugetPackage.Name)'"
+         $ModuleName = $NugetPackage.Name
+         $cacheinfo.Name = $NugetPackage.Name
+      }
 
       # For the management of a new version in the directory of an EXISTING module (see the image of the runner)
       # the new version number is added to the name of the save path, if it is specified.
       # We manage the following cases:
-      #     'Pester::' , 'Pester:5.3.0-rc1', 'Pester:5.3.0'
+      #     'ModuleName::' , 'ModuleName:5.3.0-rc1', 'ModuleName:5.3.0'
       #
-      # But we do not manage the following case: 'Pester'
+      # But we do not manage the following case: 'ModuleName'
       $Version = $cacheinfo.Version
       $isVersion = $Version -ne [String]::Empty
 


### PR DESCRIPTION
Close issue #45.

The modification reads the repository in order to find the module name to pass as a parameter to the 'Cache' action.
For each module specified as a parameter, the repository is read twice. Once when constructing pathnames and second time when saving the module (Save-Module).

For the moment the cache key name uses the module names specified in the parameters. I don't know if the cache key name is case sensitive. To be checked.

As module dependencies need to be specified in the list of paths to save, for now I leave these redundant readings and will correct this later once analyze the impacts of dependency support (if possible).

The 'UbuntuRestoreCache' test workflow is configured with 'workflow_dispatch'.
I plan to rearrange/delete existing workflows.

I haven't added a 'Pester' test for this case yet. It remains to be done.