### PR TITLE
Bump actions/cache to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
 
     - name: Run module cacher action
       id: cacher
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4.0.1
       with:
         key: ${{ steps.psoutput.outputs.keygen }}
         path: |


### PR DESCRIPTION
PSModuleCache currently generates a warning about node 16 being EOL and deprecated in Github Actions, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

PR bumps `actions/cache` dependency to latest v4 using node 20.