### PR TITLE
Upgrade to actions/cache v4.2.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
 
     - name: Run module cacher action
       id: cacher
-      uses: actions/cache@v4.0.1
+      uses: actions/cache@v4.2.0
       with:
         key: ${{ steps.psoutput.outputs.keygen }}
         path: |


### PR DESCRIPTION
Use latest version of cache action. 

Previous versions are being deprecated (as per https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down). This includes some minor versions (eg 4.0.1) - see also https://github.com/actions/cache/discussions/1510

Fixes #64