### PR TITLE
Update actions/cache version to v5.0.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
 
     - name: Run module cacher action
       id: cacher
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@v5.0.5
       with:
         key: ${{ steps.psoutput.outputs.keygen }}
         path: |


### PR DESCRIPTION
This pull request updates the caching action version used in the workflow configuration to ensure compatibility and benefit from the latest improvements and bug fixes.

Dependency update:

* Updated the `actions/cache` action from version `v4.2.0` to `v5.0.5` in the `action.yml` workflow file.

Fixes:
> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4.2.0. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/